### PR TITLE
Fix Chinese typos and broken CN/EN links in vLLM GPU deployment best practices

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ We evaluated Fun-ASR against other state-of-the-art models on open-source benchm
 
 ## Remarkable Third-Party Work
 
-- vLLM (GPU) Deployment Best Practices: An accelerated implementation of Fun-ASR using vLLM. [Repository](https://github.com/yuekaizhang/Fun-ASR-vllm/README.md)
+- vLLM (GPU) Deployment Best Practices: An accelerated implementation of Fun-ASR using vLLM. [Repository](https://github.com/yuekaizhang/Fun-ASR-vllm)
 
 ## Citations
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -196,7 +196,7 @@ if __name__ == "__main__":
 
 ## 优秀三方工作
 
-- vLLM (GPU) 最佳部署时间: 使用 vLLM 实现对 Fun-ASR 的加速. [Repository](https://github.com/yuekaizhang/Fun-ASR-vllm/README.md)
+- vLLM (GPU) 最佳部署实践: 使用 vLLM 实现对 Fun-ASR 的加速. [Repository](https://github.com/yuekaizhang/Fun-ASR-vllm)
 
 ## Citations
 


### PR DESCRIPTION
This PR improves the README documentation for `vLLM GPU deployment best practices` by:

- Fixing Chinese typos "时间" to "实践" in the Chinese version
- Repairing invalid links in both Chinese and English versions

No functional changes are introduced. Documentation only.
