### PR TITLE
fix: replace bare except clauses with Exception

### DIFF
--- a/tools/utils.py
+++ b/tools/utils.py
@@ -52,6 +52,6 @@ def forced_align(log_probs: torch.Tensor, targets: torch.Tensor, blank: int = 0)
                     "score": round(score, 3),
                 }
             )
-    except:
+    except Exception:
         pass
     return items

--- a/tools/whisper_mix_normalize.py
+++ b/tools/whisper_mix_normalize.py
@@ -46,13 +46,13 @@ def safe_ja_g2p(text, kana=True, max_length=100):
             try:
                 converted = pyopenjtalk.g2p(part, kana=kana)
                 parts.append(converted)
-            except:
+            except Exception:
                 parts.append(part)  # 如果转换失败，使用原文本
         return ' '.join(parts)
     else:
         try:
             return pyopenjtalk.g2p(text, kana=kana)
-        except:
+        except Exception:
             return text  # 如果转换失败，返回原文本
 
 


### PR DESCRIPTION
Replace 3 bare `except:` with `except Exception:` in `tools/utils.py` and `tools/whisper_mix_normalize.py` to avoid catching `SystemExit`/`KeyboardInterrupt`.