### PR TITLE
docs: document that Fun-ASR-Nano released checkpoint lacks trained CTC weights, so timestamps are unreliable

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ pip install -r requirements.txt
 # TODO
 
 - [x] Support returning timestamps
+  > **Known limitation:** In the current open-source release, the released Fun-ASR-Nano `model.pt` checkpoint does not include trained `ctc_decoder.*` / `ctc.*` weights, so timestamp output may be returned but is not reliable. For accurate character-level timestamps, use Paraformer instead, for example `AutoModel(model="paraformer-zh", vad_model="fsmn-vad", ...)`. See [issue #106](https://github.com/FunAudioLLM/Fun-ASR/issues/106).
 - [x] Support speaker diarization
 - [x] Support model training
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -63,6 +63,7 @@ pip install -r requirements.txt
 # TODO
 
 - [x] 支持返回时间戳
+  > **已知限制：** 当前开源版本发布的 Fun-ASR-Nano `model.pt` 模型检查点不包含已训练的 `ctc_decoder.*` / `ctc.*` 权重，因此可能会返回时间戳结果，但结果不可靠。需要准确的字级时间戳时，请改用 Paraformer，例如 `AutoModel(model="paraformer-zh", vad_model="fsmn-vad", ...)`。详情见 [issue #106](https://github.com/FunAudioLLM/Fun-ASR/issues/106)。
 - [ ] 支持区分说话人识别
 - [x] 支持模型训练
 


### PR DESCRIPTION
## Summary

Documents the timestamp limitation @LauraGPT confirmed in #106: the released Fun-ASR-Nano `model.pt` checkpoint ships without trained `ctc_decoder.*` / `ctc.*` weights, so the CTC forced-alignment branch returns timestamps that are not reliable. The note sits directly under the "Support returning timestamps" TODO item in both README.md and README_zh.md, with the maintainer's Paraformer (`paraformer-zh` + `fsmn-vad`) workaround and a link to the issue.

Refs #106
