### PR TITLE
docs: link the official llama.cpp / GGUF (CPU/edge) runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ pip install -r requirements.txt
 
 ## Inference
 
+> **CPU / edge (no GPU, no Python):** run Fun-ASR-Nano as a single self-contained binary via **llama.cpp / GGUF** — like whisper.cpp. See [runtime/llama.cpp/](runtime/llama.cpp/).
+
 ### Using funasr for inference
 
 ```python


### PR DESCRIPTION
One-line CPU/edge callout linking the merged runtime/llama.cpp/. Docs-only.