### PR TITLE
docs: build note for funasr-common (A1 follow-up)

### DIFF
--- a/runtime/llama.cpp/README.md
+++ b/runtime/llama.cpp/README.md
@@ -50,6 +50,7 @@ path — exactly how llava/mtmd inject vision embeddings.
 **1. Build** (drop the examples into a llama.cpp checkout):
 ```bash
 git clone https://github.com/ggml-org/llama.cpp && cd llama.cpp
+cp -r /path/to/runtime/llama.cpp/funasr-common examples/   # shared audio loader (miniaudio); each example CMake adds ../funasr-common
 cp -r /path/to/runtime/llama.cpp/funasr-cli examples/
 echo 'add_subdirectory(funasr-cli)' >> examples/CMakeLists.txt
 cmake -B build -DGGML_NATIVE=ON -DLLAMA_CURL=OFF


### PR DESCRIPTION
Adds the missing build step: copy `funasr-common/` (shared miniaudio audio loader) into `examples/` alongside the example dir; each example's CMake includes `../funasr-common`. Closes the A1 follow-up requested in review.