### PR TITLE
fix: B1 script portability (HF CLI fallback + friendly missing-dep error)

### DIFF
--- a/runtime/llama.cpp/convert-funasr-to-gguf.py
+++ b/runtime/llama.cpp/convert-funasr-to-gguf.py
@@ -42,11 +42,15 @@ def find_script(name):
 
 def download(key, src):
     hf_repo, ms_id, _, _, _ = MODELS[key]
-    if src == "modelscope":
-        from modelscope import snapshot_download
-        return snapshot_download(ms_id)
-    from huggingface_hub import snapshot_download
-    return snapshot_download(hf_repo)
+    try:
+        if src == "modelscope":
+            from modelscope import snapshot_download
+            return snapshot_download(ms_id)
+        from huggingface_hub import snapshot_download
+        return snapshot_download(hf_repo)
+    except ModuleNotFoundError as e:
+        pkg = "modelscope" if src == "modelscope" else "huggingface_hub"
+        sys.exit(f"error: missing {e.name} - install it with: pip install -U {pkg}")
 
 def pick(d, *names):
     for n in names:

--- a/runtime/llama.cpp/download-funasr-model.sh
+++ b/runtime/llama.cpp/download-funasr-model.sh
@@ -14,10 +14,13 @@ case "$MODEL" in
   fsmn-vad|vad) REPO="FunAudioLLM/fsmn-vad-GGUF" ;;
   *) usage ;;
 esac
-command -v hf >/dev/null 2>&1 || { echo "install first: pip install -U huggingface_hub"; exit 1; }
+# huggingface_hub ships `hf` (new CLI); older versions only have `huggingface-cli` (deprecated). Use whichever exists.
+if   command -v hf              >/dev/null 2>&1; then HF=hf
+elif command -v huggingface-cli >/dev/null 2>&1; then HF=huggingface-cli
+else echo "need the Hugging Face CLI: pip install -U huggingface_hub"; exit 1; fi
 mkdir -p "$OUT"
-echo "downloading $REPO ..."; hf download "$REPO" --include "*.gguf" --local-dir "$OUT"
+echo "downloading $REPO ..."; "$HF" download "$REPO" --include "*.gguf" --local-dir "$OUT"
 if [ "$MODEL" != "fsmn-vad" ] && [ "$MODEL" != "vad" ]; then
-  echo "downloading FSMN-VAD (for --vad) ..."; hf download FunAudioLLM/fsmn-vad-GGUF --include "*.gguf" --local-dir "$OUT"
+  echo "downloading FSMN-VAD (for --vad) ..."; "$HF" download FunAudioLLM/fsmn-vad-GGUF --include "*.gguf" --local-dir "$OUT"
 fi
 echo "done -> $OUT"; ls -1 "$OUT"/*.gguf


### PR DESCRIPTION
Addresses the gemini-code-assist findings on the merged B1 packaging PR.

- **`download-funasr-model.sh` (HIGH)** — used `hf`, which older `huggingface_hub` installs don't ship (only `huggingface-cli`). Now detects `hf`, falls back to `huggingface-cli`, and fails with an install hint if neither is present. (`hf download` and `huggingface-cli download` take the same args.)
- **`convert-funasr-to-gguf.py` (medium)** — catch `ModuleNotFoundError` and print `pip install -U <pkg>` instead of a raw traceback.

Verified: `download-funasr-model.sh fsmn-vad` still pulls + the script passes `bash -n`; convert compiles. Keeps the one-command "download-and-run" flow working across `huggingface_hub` versions.