### PR TITLE
docs: clarify GGUF VAD download path

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Online Experience:
 
 # What's New 🔥
 
-- 2026/06: **Fun-ASR-Nano on llama.cpp / GGUF** — run it on CPU/edge as a single self-contained binary (whisper.cpp-style), built-in VAD, no Python at runtime. Quantized models down to ~484 MB. [runtime/llama.cpp/](./runtime/llama.cpp/) · [Releases](../../releases) · [GGUF on Hugging Face](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-GGUF)
+- 2026/06: **Fun-ASR-Nano on llama.cpp / GGUF** — run it on CPU/edge as a single self-contained binary (whisper.cpp-style), built-in VAD, no Python at runtime. Quantized models down to ~484 MB. [runtime/llama.cpp/](./runtime/llama.cpp/) · [Releases](../../releases) · [Nano GGUF](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-GGUF) · [FSMN-VAD GGUF](https://huggingface.co/FunAudioLLM/fsmn-vad-GGUF)
 - 2026/05: **vLLM Inference Engine** — native high-throughput batch (3-5x faster) + WebSocket real-time streaming service. See [vLLM Guide](docs/vllm_guide.md).
 - 2026/05: Fun-ASR-Nano now supports speaker diarization. Use with `vad_model` + `spk_model` + `punc_model` to get per-sentence speaker labels. Requires installing FunASR from source: `pip install git+https://github.com/modelscope/FunASR.git`
 - 2025/12: [Fun-ASR-Nano-2512](https://modelscope.cn/models/FunAudioLLM/Fun-ASR-Nano-2512) is an end-to-end speech recognition large model trained on tens of millions of hours real speech data. It supports low-latency real-time transcription and covers 31 languages.
@@ -81,11 +81,17 @@ pip install -r requirements.txt
 Run Fun-ASR-Nano as a **single self-contained binary** — like [whisper.cpp](https://github.com/ggml-org/whisper.cpp) but for FunASR, with strong Chinese accuracy. Built-in FSMN-VAD, no Python at runtime.
 
 ```bash
-bash download-funasr-model.sh nano ./gguf
+bash runtime/llama.cpp/download-funasr-model.sh nano ./gguf
 llama-funasr-cli --enc ./gguf/funasr-encoder-f16.gguf -m ./gguf/qwen3-0.6b-q8_0.gguf -a audio.wav --vad ./gguf/fsmn-vad.gguf
 ```
 
-**Prebuilt binaries:** [Releases](../../releases) · **Download & quickstart:** [funasr.com/llama-cpp](https://www.funasr.com/llama-cpp.html) · **GGUF:** [Hugging Face](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-GGUF) · **Docs & benchmarks:** [runtime/llama.cpp/](./runtime/llama.cpp/)
+`fsmn-vad.gguf` is hosted in the shared [FunAudioLLM/fsmn-vad-GGUF](https://huggingface.co/FunAudioLLM/fsmn-vad-GGUF) repo, not inside the Nano GGUF repo. The `nano` downloader above fetches it automatically; to fetch only VAD from the Hugging Face UI/CLI, use:
+
+```bash
+hf download FunAudioLLM/fsmn-vad-GGUF --include "*.gguf" --local-dir ./gguf
+```
+
+**Prebuilt binaries:** [Releases](../../releases) · **Download & quickstart:** [funasr.com/llama-cpp](https://www.funasr.com/llama-cpp.html) · **GGUF:** [Nano encoder/LLM](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-GGUF) · [FSMN-VAD](https://huggingface.co/FunAudioLLM/fsmn-vad-GGUF) · **Docs & benchmarks:** [runtime/llama.cpp/](./runtime/llama.cpp/)
 
 ### Using funasr for inference
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -36,6 +36,7 @@ Fun-ASR 是通义实验室推出的端到端语音识别大模型，是基于数
 
 # 最新动态 🔥
 
+- 2026/06: **Fun-ASR-Nano on llama.cpp / GGUF** — 支持在 CPU/边缘设备上以单个自包含二进制运行（类似 whisper.cpp），内置 VAD，运行时无需 Python。量化模型最小约 484 MB。[runtime/llama.cpp/](./runtime/llama.cpp/) · [Releases](../../releases) · [Nano GGUF](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-GGUF) · [FSMN-VAD GGUF](https://huggingface.co/FunAudioLLM/fsmn-vad-GGUF)
 - 2026/05: **vLLM 推理引擎** — 原生高吞吐批量推理（3-5 倍加速）+ WebSocket 实时流式服务。参见 [vLLM 指南](docs/vllm_guide.md)。
 - 2026/05: Fun-ASR-Nano 现已支持说话人分离。配合 `vad_model` + `spk_model` + `punc_model` 使用，可获得带说话人标签的逐句结果。需从源码安装 FunASR：`pip install git+https://github.com/modelscope/FunASR.git`
 - 2025/12: [Fun-ASR-Nano-2512](https://modelscope.cn/models/FunAudioLLM/Fun-ASR-Nano-2512) 是一款基于数千万小时真实语音数据训练的端到端语音识别大模型。它支持低延迟实时转写，并涵盖 31 种语言识别功能。
@@ -72,6 +73,23 @@ pip install -r requirements.txt
 # 用法 🛠️
 
 ## 推理
+
+### CPU / 边缘设备运行 — llama.cpp / GGUF（无 GPU、无 Python 运行时）
+
+Fun-ASR-Nano 可作为单个自包含二进制运行，类似 [whisper.cpp](https://github.com/ggml-org/whisper.cpp)，内置 FSMN-VAD，适合离线 CPU/边缘部署。
+
+```bash
+bash runtime/llama.cpp/download-funasr-model.sh nano ./gguf
+llama-funasr-cli --enc ./gguf/funasr-encoder-f16.gguf -m ./gguf/qwen3-0.6b-q8_0.gguf -a audio.wav --vad ./gguf/fsmn-vad.gguf
+```
+
+`fsmn-vad.gguf` 独立发布在共享的 [FunAudioLLM/fsmn-vad-GGUF](https://huggingface.co/FunAudioLLM/fsmn-vad-GGUF) 仓库中，不在 Nano GGUF 仓库内。上面的 `nano` 下载脚本会自动拉取；如果只想单独下载 VAD 文件，可使用：
+
+```bash
+hf download FunAudioLLM/fsmn-vad-GGUF --include "*.gguf" --local-dir ./gguf
+```
+
+**预编译二进制：** [Releases](../../releases) · **下载与快速开始：** [funasr.com/llama-cpp](https://www.funasr.com/llama-cpp.html) · **GGUF：** [Nano encoder/LLM](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-GGUF) · [FSMN-VAD](https://huggingface.co/FunAudioLLM/fsmn-vad-GGUF) · **文档与 benchmark：** [runtime/llama.cpp/](./runtime/llama.cpp/)
 
 ### 使用 funasr 推理
 

--- a/runtime/llama.cpp/README.md
+++ b/runtime/llama.cpp/README.md
@@ -53,6 +53,12 @@ llama-funasr-cli --enc funasr-gguf/funasr-encoder-f16.gguf -m funasr-gguf/qwen3-
 ```
 Pre-converted GGUF: [FunAudioLLM/Fun-ASR-Nano-GGUF](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-GGUF) · [fsmn-vad-GGUF](https://huggingface.co/FunAudioLLM/fsmn-vad-GGUF). Or convert yourself: `python convert-funasr-to-gguf.py nano-encoder --wtype f16`.
 
+`fsmn-vad.gguf` is intentionally published in the separate [FunAudioLLM/fsmn-vad-GGUF](https://huggingface.co/FunAudioLLM/fsmn-vad-GGUF) repo so Nano, SenseVoice, and Paraformer can share the same VAD file. The `nano` command above downloads it automatically; if you are browsing the Hugging Face UI, open the VAD repo directly, or fetch it with:
+
+```bash
+hf download FunAudioLLM/fsmn-vad-GGUF --include "*.gguf" --local-dir funasr-gguf
+```
+
 ## Build (standalone, CI-friendly)
 ```bash
 cmake -B build -DCMAKE_BUILD_TYPE=Release      # fetches pinned llama.cpp; static, self-contained


### PR DESCRIPTION
## Summary

- Clarify that `fsmn-vad.gguf` is hosted in the shared `FunAudioLLM/fsmn-vad-GGUF` Hugging Face repo, not inside `FunAudioLLM/Fun-ASR-Nano-GGUF`.
- Fix the top-level quickstart command to call the real script path: `runtime/llama.cpp/download-funasr-model.sh`.
- Add a Chinese README GGUF quickstart section so users hitting issue #131 can find the VAD download path from the main Chinese entrypoint.

Fixes #131.

## Verification

```bash
git diff --check origin/main...HEAD
bash -n runtime/llama.cpp/download-funasr-model.sh
rg -n "fsmn-vad-GGUF|download-funasr-model\.sh|fsmn-vad\.gguf" README.md README_zh.md runtime/llama.cpp/README.md
```

Earlier live checks on ind-gpu8 also verified that `fsmn-vad.gguf` is absent from `FunAudioLLM/Fun-ASR-Nano-GGUF`, present in `FunAudioLLM/fsmn-vad-GGUF`, and downloads as a 1,720,512-byte file.
