### PR TITLE
feat: expose realtime websocket server options

### DIFF
--- a/docs/realtime_demo.md
+++ b/docs/realtime_demo.md
@@ -16,8 +16,12 @@ pip install -r requirements.txt
 pip install vllm>=0.12.0
 
 # 启动服务
-CUDA_VISIBLE_DEVICES=0 python serve_realtime_ws.py --port 10095 --language 中文
+CUDA_VISIBLE_DEVICES=0 python serve_realtime_ws.py \
+    --port 10095 --language 中文 \
+    --ws-ping-interval 30 --ws-ping-timeout 120
 ```
+
+长时间会议、访谈或经过 Nginx/负载均衡访问时，可按网络空闲回收时间调整 `--ws-ping-interval` 与 `--ws-ping-timeout`。如果外部网关已经负责心跳和重连，可将两者设为 `0` 关闭 WebSocket 协议层 ping。
 
 ## 客户端
 

--- a/docs/vllm_guide.md
+++ b/docs/vllm_guide.md
@@ -542,8 +542,18 @@ Client (microphone / audio stream)     serve_realtime_ws.py
 
 ```bash
 CUDA_VISIBLE_DEVICES=0 python examples/industrial_data_pretraining/fun_asr_nano/serve_realtime_ws.py \
-    --port 10095 --language 中文 --hotword-file hotword_list
+    --port 10095 --language 中文 --hotword-file hotword_list \
+    --ws-ping-interval 30 --ws-ping-timeout 120
 ```
+
+For long meetings or connections routed through Nginx/load balancers, tune the WebSocket keepalive settings to stay below the idle timeout enforced by the gateway:
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--ws-ping-interval` | `30.0` | Seconds between WebSocket protocol pings; set `0` to disable protocol pings |
+| `--ws-ping-timeout` | `120.0` | Seconds to wait for a pong before closing; set `0` to disable the ping timeout |
+| `--ws-close-timeout` | `10.0` | Seconds to wait for the WebSocket close handshake |
+| `--ws-max-size` | `10485760` | Maximum incoming WebSocket message size in bytes |
 
 ### 6.3 WebSocket Protocol
 

--- a/docs/vllm_guide_zh.md
+++ b/docs/vllm_guide_zh.md
@@ -544,8 +544,18 @@ asyncio.run(offline_ws("audio.wav"))
 
 ```bash
 CUDA_VISIBLE_DEVICES=0 python examples/industrial_data_pretraining/fun_asr_nano/serve_realtime_ws.py \
-    --port 10095 --language 中文 --hotword-file 热词列表
+    --port 10095 --language 中文 --hotword-file 热词列表 \
+    --ws-ping-interval 30 --ws-ping-timeout 120
 ```
+
+长时间会议、访谈或经过 Nginx/负载均衡访问时，请按网关的空闲回收时间调整 WebSocket 保活参数：
+
+| 参数 | 默认值 | 说明 |
+|------|--------|------|
+| `--ws-ping-interval` | `30.0` | WebSocket 协议 ping 间隔秒数；设为 `0` 可关闭协议层 ping |
+| `--ws-ping-timeout` | `120.0` | 等待 pong 的超时时间秒数；设为 `0` 可关闭 ping timeout |
+| `--ws-close-timeout` | `10.0` | WebSocket close 握手等待秒数 |
+| `--ws-max-size` | `10485760` | 单条 WebSocket 入站消息最大字节数 |
 
 ### 4.3 WebSocket 协议
 

--- a/serve_realtime_ws.py
+++ b/serve_realtime_ws.py
@@ -493,14 +493,27 @@ async def handle_client(websocket, args):
         logger.error(f"Error: {e}", exc_info=True)
 
 
+def _positive_or_none(value):
+    return None if value <= 0 else value
+
+
+def build_websocket_serve_kwargs(args):
+    return {
+        "ping_interval": _positive_or_none(args.ws_ping_interval),
+        "ping_timeout": _positive_or_none(args.ws_ping_timeout),
+        "close_timeout": args.ws_close_timeout,
+        "max_size": args.ws_max_size,
+    }
+
+
 async def main(args):
     load_models(args)
+    serve_kwargs = build_websocket_serve_kwargs(args)
     logger.info(f"Server on ws://0.0.0.0:{args.port}")
+    logger.info(f"WebSocket options: {serve_kwargs}")
     async with websockets.serve(
         lambda ws: handle_client(ws, args), "0.0.0.0", args.port,
-        ping_interval=args.ws_ping_interval,
-        ping_timeout=args.ws_ping_timeout,
-        max_size=10*1024*1024,
+        **serve_kwargs,
     ):
         await asyncio.Future()
 
@@ -515,8 +528,14 @@ if __name__ == "__main__":
     parser.add_argument("--no-context", dest="use_context", action="store_false")
     parser.add_argument("--decode-interval", type=float, default=0.48)
     parser.add_argument("--disable-spk", action="store_true", help="Disable streaming speaker diarization")
-    parser.add_argument("--ws-ping-interval", type=float, default=30.0, help="WebSocket ping interval in seconds")
-    parser.add_argument("--ws-ping-timeout", type=float, default=120.0, help="WebSocket ping timeout in seconds")
+    parser.add_argument("--ws-ping-interval", type=float, default=30.0,
+                        help="WebSocket ping interval in seconds; <=0 disables protocol pings")
+    parser.add_argument("--ws-ping-timeout", type=float, default=120.0,
+                        help="WebSocket ping timeout in seconds; <=0 disables ping timeout")
+    parser.add_argument("--ws-close-timeout", type=float, default=10.0,
+                        help="WebSocket close handshake timeout in seconds")
+    parser.add_argument("--ws-max-size", type=int, default=10 * 1024 * 1024,
+                        help="Maximum WebSocket message size in bytes")
     parser.add_argument("--hotword-file", type=str, default="热词列表")
     parser.add_argument("--language", type=str, default=None, help="Language hint (e.g. 中文, English, 日本語)")
     parser.add_argument("--dtype", type=str, default="bf16", choices=["bf16", "fp16", "fp32"])

--- a/tests/test_serve_realtime_ws_static.py
+++ b/tests/test_serve_realtime_ws_static.py
@@ -14,8 +14,23 @@ def test_realtime_server_exposes_long_session_controls():
     assert 'parser.add_argument("--disable-spk"' in source
     assert 'parser.add_argument("--ws-ping-interval"' in source
     assert 'parser.add_argument("--ws-ping-timeout"' in source
-    assert "ping_interval=args.ws_ping_interval" in source
-    assert "ping_timeout=args.ws_ping_timeout" in source
+    assert 'parser.add_argument("--ws-close-timeout"' in source
+    assert 'parser.add_argument("--ws-max-size"' in source
+    assert "build_websocket_serve_kwargs(args)" in source
+    assert "ping_interval" in source
+    assert "ping_timeout" in source
+    assert "close_timeout" in source
+    assert "max_size" in source
+
+
+def test_realtime_server_allows_disabling_websocket_pings():
+    source = _source_text()
+
+    assert "def _positive_or_none" in source
+    assert "return None if value <= 0 else value" in source
+    assert "_positive_or_none(args.ws_ping_interval)" in source
+    assert "_positive_or_none(args.ws_ping_timeout)" in source
+    assert "<=0 disables" in source
 
 
 def test_realtime_server_keeps_heavy_session_work_off_event_loop():


### PR DESCRIPTION
## Summary

- Adds a shared `build_websocket_serve_kwargs()` path for realtime WebSocket server options.
- Exposes `--ws-close-timeout` and `--ws-max-size` alongside the existing ping interval/timeout options.
- Allows `--ws-ping-interval <= 0` and `--ws-ping-timeout <= 0` to disable protocol-level pings/timeouts when an external gateway owns keepalive and reconnect behavior.
- Documents keepalive tuning in the realtime quick-start plus English and Chinese vLLM guides.

## Why

Long-running meetings and interview transcription sessions often sit behind Nginx or cloud load balancers. Making the WebSocket keepalive and message-size controls explicit reduces idle disconnects and gives operators a documented escape hatch for gateway-managed keepalive setups.

## Validation

- `python3 -m pytest tests/test_serve_realtime_ws_static.py -q`
- `python3 -m py_compile serve_realtime_ws.py`
- `git diff --check`
- Static source assertions for the new argparse and `websockets.serve` options

Not run: full realtime WebSocket service startup, because this ops environment does not have the `funasr` runtime package installed for `serve_realtime_ws.py` imports.
