### PR TITLE
docs: clarify source and model licenses

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,11 @@ Fun-ASR-Nano is part of the **FunAudioLLM** family:
   </picture>
 </a>
 
+## License
+
+- Source code in this repository is licensed under the [Apache License 2.0](./LICENSE).
+- Model weights are distributed separately and follow the license metadata on their model cards. The official [Fun-ASR-Nano](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-2512) and [Fun-ASR-MLT-Nano](https://huggingface.co/FunAudioLLM/Fun-ASR-MLT-Nano-2512) cards currently list Apache-2.0; review the card for the specific artifact you download.
+
 ## Citations
 
 ```bibtex

--- a/README_zh.md
+++ b/README_zh.md
@@ -223,6 +223,11 @@ if __name__ == "__main__":
 
 > Fun-ASR 也已内置原生 vLLM 支持，包括 `AutoModelVLLM` 批量推理、Streaming SDK 和 WebSocket 服务；请参考 [vLLM 中文指南](docs/vllm_guide_zh.md) 与 [可运行示例脚本](examples/README.md)。
 
+## 许可证
+
+- 本仓库源码采用 [Apache License 2.0](./LICENSE)。
+- 模型权重单独发布，并以各模型卡标注的许可证为准。官方 [Fun-ASR-Nano](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-2512) 与 [Fun-ASR-MLT-Nano](https://huggingface.co/FunAudioLLM/Fun-ASR-MLT-Nano-2512) 模型卡目前均标注 Apache-2.0；请在下载具体制品前再次核对对应模型卡。
+
 ## Citations
 
 ```bibtex


### PR DESCRIPTION
## Summary
- document the Apache-2.0 source-code license
- clarify that downloaded model weights follow their model-card metadata
- link the official Nano and MLT-Nano cards from both English and Chinese READMEs

## Verification
- `git diff --check`
- all new links returned HTTP 200
- Hugging Face API reports `apache-2.0` for both linked official model cards