### PR TITLE
docs: correct Nano Colab capability notes

### DIFF
--- a/examples/colab/fun_asr_nano_quickstart.ipynb
+++ b/examples/colab/fun_asr_nano_quickstart.ipynb
@@ -22,7 +22,7 @@
       "source": [
         "# Fun-ASR-Nano Quickstart\n",
         "\n",
-        "**End-to-end speech recognition large model** — 31 languages, dialects, timestamps, hotwords, speaker diarization.\n",
+        "**End-to-end speech recognition large model** — Fun-ASR-Nano-2512 supports Chinese, English, Japanese, and Chinese dialect/accent speech. For 31-language ASR, use the separate Fun-ASR-MLT-Nano-2512 checkpoint.\n",
         "\n",
         "[![GitHub](https://img.shields.io/github/stars/FunAudioLLM/Fun-ASR?style=social)](https://github.com/FunAudioLLM/Fun-ASR)\n",
         "[![Website](https://img.shields.io/badge/website-funasr.com-blue)](https://www.funasr.com)\n",
@@ -92,11 +92,14 @@
       "outputs": [],
       "source": [
         "result = model.generate(input=[wav_path], batch_size=1)\n",
-        "# Timestamps are included in the output\n",
+        "# The current released Nano checkpoint may return a timestamp field, but it\n",
+        "# does not include trained CTC timestamp weights. Treat timestamps as\n",
+        "# experimental and use Paraformer when accurate character-level timestamps are\n",
+        "# required.\n",
         "for item in result:\n",
         "    print(f\"Text: {item['text']}\")\n",
         "    if 'timestamp' in item:\n",
-        "        print(f\"Timestamps: {item['timestamp']}\")"
+        "        print(f\"Experimental timestamps: {item['timestamp']}\")\n"
       ]
     },
     {
@@ -193,7 +196,8 @@
         "- **GitHub:** [FunAudioLLM/Fun-ASR](https://github.com/FunAudioLLM/Fun-ASR) ⭐\n",
         "- **Toolkit:** [modelscope/FunASR](https://github.com/modelscope/FunASR)\n",
         "- **Website:** [www.funasr.com](https://www.funasr.com)\n",
-        "- **Models:** [HuggingFace](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-2512) · [ModelScope](https://modelscope.cn/models/FunAudioLLM/Fun-ASR-Nano-2512)\n",
+        "- **Nano model:** [HuggingFace](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-2512) · [ModelScope](https://modelscope.cn/models/FunAudioLLM/Fun-ASR-Nano-2512)\n",
+        "- **31-language MLT model:** [HuggingFace](https://huggingface.co/FunAudioLLM/Fun-ASR-MLT-Nano-2512) · [ModelScope](https://modelscope.cn/models/FunAudioLLM/Fun-ASR-MLT-Nano-2512)\n",
         "\n",
         "If Fun-ASR-Nano helps your project, please consider giving us a ⭐ on GitHub!"
       ]


### PR DESCRIPTION
## Summary
- update the Colab headline so Fun-ASR-Nano-2512 is not described as the 31-language checkpoint
- mark Nano timestamps as experimental because the released checkpoint lacks trained CTC timestamp weights
- link the separate Fun-ASR-MLT-Nano-2512 model from the Colab links section

## Validation
- python JSON parse of examples/colab/fun_asr_nano_quickstart.ipynb
- targeted notebook assertions for Nano/MLT/timestamp wording
- git diff --check