### PR TITLE
docs: require current FunASR release

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ for result in engine.streaming_generate("audio.wav", language="中文"):
 ### Install
 
 ```bash
-pip install funasr>=1.3.3 vllm>=0.12.0
+pip install "funasr>=1.3.19" "vllm>=0.12.0"
 ```
 
 # Finetune

--- a/docs/finetune.md
+++ b/docs/finetune.md
@@ -5,7 +5,7 @@
 ## Requirements
 
 ```
-pip install funasr>=1.3.0
+pip install "funasr>=1.3.19"
 ```
 
 ## Data Prepare

--- a/docs/finetune_zh.md
+++ b/docs/finetune_zh.md
@@ -5,7 +5,7 @@
 ## 安装训练环境
 
 ```
-pip install funasr>=1.3.0
+pip install "funasr>=1.3.19"
 ```
 
 ## 数据准备

--- a/docs/vllm_guide.md
+++ b/docs/vllm_guide.md
@@ -35,7 +35,7 @@
 ## 1. Installation & Environment
 
 ```bash
-pip install funasr>=1.3.0
+pip install "funasr>=1.3.19"
 pip install vllm>=0.12.0
 pip install safetensors tiktoken websockets regex fastapi uvicorn python-multipart
 

--- a/docs/vllm_guide_zh.md
+++ b/docs/vllm_guide_zh.md
@@ -35,7 +35,7 @@
 ## 1. 安装与环境
 
 ```bash
-pip install funasr>=1.3.0
+pip install "funasr>=1.3.19"
 pip install vllm>=0.12.0
 pip install safetensors tiktoken websockets regex fastapi uvicorn python-multipart
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -42,7 +42,7 @@ python examples/speaker_diarization.py path/to/meeting.wav
 Install vLLM before running this example:
 
 ```bash
-pip install "funasr>=1.3.3" "vllm>=0.12.0"
+pip install "funasr>=1.3.19" "vllm>=0.12.0"
 python examples/vllm_batch.py --tensor-parallel-size 1
 python examples/vllm_batch.py audio1.wav audio2.wav --hotwords 张三 北京
 ```
@@ -55,7 +55,7 @@ the audio first or use the `AutoModel(..., vad_model="fsmn-vad")` path.
 Install vLLM before running this example:
 
 ```bash
-pip install "funasr>=1.3.3" "vllm>=0.12.0"
+pip install "funasr>=1.3.19" "vllm>=0.12.0"
 python examples/streaming_sdk.py --hub hf --chunk-ms 720
 python examples/streaming_sdk.py path/to/audio.wav
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 torch>=2.9.0
 torchaudio>=2.9.0
 transformers>=4.51.3
-funasr>=1.3.0
+funasr>=1.3.19
 zhconv
 whisper_normalizer
 pyopenjtalk-plus

--- a/tests/test_funasr_requirement.py
+++ b/tests/test_funasr_requirement.py
@@ -1,0 +1,32 @@
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+DOCS = [
+    "README.md",
+    "docs/finetune.md",
+    "docs/finetune_zh.md",
+    "docs/vllm_guide.md",
+    "docs/vllm_guide_zh.md",
+    "examples/README.md",
+]
+
+
+def test_funasr_requirement_uses_current_release_floor():
+    requirements = (ROOT / "requirements.txt").read_text()
+    assert "funasr>=1.3.19" in requirements
+    assert "funasr>=1.3.0" not in requirements
+
+
+def test_docs_use_quoted_current_funasr_install_commands():
+    for relpath in DOCS:
+        text = (ROOT / relpath).read_text()
+        assert "funasr>=1.3.0" not in text
+        assert "funasr>=1.3.3" not in text
+        assert not re.search(r"pip install funasr>=", text)
+
+    assert '"funasr>=1.3.19"' in (ROOT / "README.md").read_text()
+    assert (ROOT / "examples/README.md").read_text().count('"funasr>=1.3.19"') == 2


### PR DESCRIPTION
## Summary
- raise the FunASR dependency floor to funasr>=1.3.19
- update README, vLLM, finetune, and examples install commands to the current release floor
- quote pip specifiers such as "funasr>=1.3.19" so shells do not treat > as redirection
- add a static regression test for the requirement floor and quoted install commands

## Why
The model repo now points users to current FunASR, vLLM, streaming, and GGUF paths. Keeping old funasr>=1.3.0 / 1.3.3 examples can leave users below the latest shipped diagnostics and compatibility fixes, and unquoted pip specifiers are easy to mis-run in a shell.

## Validation
- python3 -m pytest tests/test_funasr_requirement.py -q
- python3 -m py_compile demo1.py demo2.py demo_vllm.py serve_realtime_ws.py model.py tests/test_funasr_requirement.py
- PyPI JSON confirms funasr 1.3.19 exists
- git diff --check