### PR TITLE
docs: require FunASR 1.3.23

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ for result in engine.streaming_generate("audio.wav", language="中文"):
 ### Install
 
 ```bash
-pip install "funasr>=1.3.19" "vllm>=0.12.0"
+pip install "funasr>=1.3.23" "vllm>=0.12.0"
 ```
 
 # Finetune

--- a/docs/finetune.md
+++ b/docs/finetune.md
@@ -5,7 +5,7 @@
 ## Requirements
 
 ```
-pip install "funasr>=1.3.19"
+pip install "funasr>=1.3.23"
 ```
 
 ## Data Prepare

--- a/docs/finetune_zh.md
+++ b/docs/finetune_zh.md
@@ -5,7 +5,7 @@
 ## 安装训练环境
 
 ```
-pip install "funasr>=1.3.19"
+pip install "funasr>=1.3.23"
 ```
 
 ## 数据准备

--- a/docs/vllm_guide.md
+++ b/docs/vllm_guide.md
@@ -35,7 +35,7 @@
 ## 1. Installation & Environment
 
 ```bash
-pip install "funasr>=1.3.19"
+pip install "funasr>=1.3.23"
 pip install vllm>=0.12.0
 pip install safetensors tiktoken websockets regex fastapi uvicorn python-multipart
 

--- a/docs/vllm_guide_zh.md
+++ b/docs/vllm_guide_zh.md
@@ -35,7 +35,7 @@
 ## 1. 安装与环境
 
 ```bash
-pip install "funasr>=1.3.19"
+pip install "funasr>=1.3.23"
 pip install vllm>=0.12.0
 pip install safetensors tiktoken websockets regex fastapi uvicorn python-multipart
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -42,7 +42,7 @@ python examples/speaker_diarization.py path/to/meeting.wav
 Install vLLM before running this example:
 
 ```bash
-pip install "funasr>=1.3.19" "vllm>=0.12.0"
+pip install "funasr>=1.3.23" "vllm>=0.12.0"
 python examples/vllm_batch.py --tensor-parallel-size 1
 python examples/vllm_batch.py audio1.wav audio2.wav --hotwords 张三 北京
 ```
@@ -55,7 +55,7 @@ the audio first or use the `AutoModel(..., vad_model="fsmn-vad")` path.
 Install vLLM before running this example:
 
 ```bash
-pip install "funasr>=1.3.19" "vllm>=0.12.0"
+pip install "funasr>=1.3.23" "vllm>=0.12.0"
 python examples/streaming_sdk.py --hub hf --chunk-ms 720
 python examples/streaming_sdk.py path/to/audio.wav
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 torch>=2.9.0
 torchaudio>=2.9.0
 transformers>=4.51.3
-funasr>=1.3.19
+funasr>=1.3.23
 zhconv
 whisper_normalizer
 pyopenjtalk-plus


### PR DESCRIPTION
## Summary
- update Fun-ASR install docs and `requirements.txt` from `funasr>=1.3.19` to `funasr>=1.3.23`
- keep vLLM and finetuning examples aligned with the current public FunASR PyPI release

## Validation
- checked that no `funasr>=1.3.19` references remain under README/docs/examples/requirements
- asserted the updated 1.3.23 install command in each changed file
- `git diff --check`
