### PR TITLE
test: expect FunASR 1.3.23 release floor

### DIFF
--- a/tests/test_funasr_requirement.py
+++ b/tests/test_funasr_requirement.py
@@ -17,8 +17,9 @@ DOCS = [
 
 def test_funasr_requirement_uses_current_release_floor():
     requirements = (ROOT / "requirements.txt").read_text()
-    assert "funasr>=1.3.19" in requirements
+    assert "funasr>=1.3.23" in requirements
     assert "funasr>=1.3.0" not in requirements
+    assert "funasr>=1.3.19" not in requirements
 
 
 def test_docs_use_quoted_current_funasr_install_commands():
@@ -26,7 +27,8 @@ def test_docs_use_quoted_current_funasr_install_commands():
         text = (ROOT / relpath).read_text()
         assert "funasr>=1.3.0" not in text
         assert "funasr>=1.3.3" not in text
+        assert "funasr>=1.3.19" not in text
         assert not re.search(r"pip install funasr>=", text)
 
-    assert '"funasr>=1.3.19"' in (ROOT / "README.md").read_text()
-    assert (ROOT / "examples/README.md").read_text().count('"funasr>=1.3.19"') == 2
+    assert '"funasr>=1.3.23"' in (ROOT / "README.md").read_text()
+    assert (ROOT / "examples/README.md").read_text().count('"funasr>=1.3.23"') == 2


### PR DESCRIPTION
## Summary
- update the FunASR release-floor regression test to match the merged `funasr>=1.3.23` docs and requirements
- add explicit guards so `funasr>=1.3.19` does not return in requirements or install docs

## Validation
- `python3 -m pytest -q tests/test_funasr_requirement.py`
- `git diff --check`
