### PR TITLE
docs: fix finetune Chinese guide link

### DIFF
--- a/docs/finetune.md
+++ b/docs/finetune.md
@@ -1,6 +1,6 @@
 # Finetune
 
-「[简体中文](fintune_zh.md)」|「English」
+「[简体中文](finetune_zh.md)」|「English」
 
 ## Requirements
 

--- a/tests/test_funasr_requirement.py
+++ b/tests/test_funasr_requirement.py
@@ -1,5 +1,6 @@
 import re
 from pathlib import Path
+from urllib.parse import unquote, urlparse
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -32,3 +33,18 @@ def test_docs_use_quoted_current_funasr_install_commands():
 
     assert '"funasr>=1.3.23"' in (ROOT / "README.md").read_text()
     assert (ROOT / "examples/README.md").read_text().count('"funasr>=1.3.23"') == 2
+
+
+def test_docs_relative_markdown_links_point_to_existing_files():
+    link_pattern = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
+    for relpath in [path for path in DOCS if path.startswith("docs/")]:
+        doc_path = ROOT / relpath
+        for target in link_pattern.findall(doc_path.read_text()):
+            parsed = urlparse(target)
+            if parsed.scheme or parsed.netloc or target.startswith("#"):
+                continue
+            link_path = unquote(parsed.path)
+            if not link_path or link_path.startswith(("#", "../")):
+                continue
+            resolved = (doc_path.parent / link_path).resolve()
+            assert resolved.exists(), f"{relpath} links to missing file: {target}"


### PR DESCRIPTION
## Summary
- Fix the English finetune guide's Simplified Chinese link from the missing `fintune_zh.md` path to the existing `finetune_zh.md` guide.
- Add a docs regression check for local Markdown links under `docs/` so this specific typo does not return.

## Validation
- `python3 -m pytest -q tests/test_funasr_requirement.py`
- `python3 -m pytest -q tests/test_examples_smoke.py`
- `git diff --check`
- Link assertions for `docs/finetune.md -> docs/finetune_zh.md`
