### PR TITLE
docs: require FunASR 1.3.24

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ for result in engine.streaming_generate("audio.wav", language="中文"):
 ### Install
 
 ```bash
-pip install "funasr>=1.3.23" "vllm>=0.12.0"
+pip install "funasr>=1.3.24" "vllm>=0.12.0"
 ```
 
 # Finetune

--- a/docs/finetune.md
+++ b/docs/finetune.md
@@ -5,7 +5,7 @@
 ## Requirements
 
 ```
-pip install "funasr>=1.3.23"
+pip install "funasr>=1.3.24"
 ```
 
 ## Data Prepare

--- a/docs/finetune_zh.md
+++ b/docs/finetune_zh.md
@@ -5,7 +5,7 @@
 ## 安装训练环境
 
 ```
-pip install "funasr>=1.3.23"
+pip install "funasr>=1.3.24"
 ```
 
 ## 数据准备

--- a/docs/vllm_guide.md
+++ b/docs/vllm_guide.md
@@ -35,7 +35,7 @@
 ## 1. Installation & Environment
 
 ```bash
-pip install "funasr>=1.3.23"
+pip install "funasr>=1.3.24"
 pip install vllm>=0.12.0
 pip install safetensors tiktoken websockets regex fastapi uvicorn python-multipart
 

--- a/docs/vllm_guide_zh.md
+++ b/docs/vllm_guide_zh.md
@@ -35,7 +35,7 @@
 ## 1. 安装与环境
 
 ```bash
-pip install "funasr>=1.3.23"
+pip install "funasr>=1.3.24"
 pip install vllm>=0.12.0
 pip install safetensors tiktoken websockets regex fastapi uvicorn python-multipart
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -42,7 +42,7 @@ python examples/speaker_diarization.py path/to/meeting.wav
 Install vLLM before running this example:
 
 ```bash
-pip install "funasr>=1.3.23" "vllm>=0.12.0"
+pip install "funasr>=1.3.24" "vllm>=0.12.0"
 python examples/vllm_batch.py --tensor-parallel-size 1
 python examples/vllm_batch.py audio1.wav audio2.wav --hotwords 张三 北京
 ```
@@ -55,7 +55,7 @@ the audio first or use the `AutoModel(..., vad_model="fsmn-vad")` path.
 Install vLLM before running this example:
 
 ```bash
-pip install "funasr>=1.3.23" "vllm>=0.12.0"
+pip install "funasr>=1.3.24" "vllm>=0.12.0"
 python examples/streaming_sdk.py --hub hf --chunk-ms 720
 python examples/streaming_sdk.py path/to/audio.wav
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 torch>=2.9.0
 torchaudio>=2.9.0
 transformers>=4.51.3
-funasr>=1.3.23
+funasr>=1.3.24
 zhconv
 whisper_normalizer
 pyopenjtalk-plus

--- a/tests/test_funasr_requirement.py
+++ b/tests/test_funasr_requirement.py
@@ -19,9 +19,10 @@ DOCS = [
 
 def test_funasr_requirement_uses_current_release_floor():
     requirements = (ROOT / "requirements.txt").read_text()
-    assert "funasr>=1.3.23" in requirements
+    assert "funasr>=1.3.24" in requirements
     assert "funasr>=1.3.0" not in requirements
     assert "funasr>=1.3.19" not in requirements
+    assert "funasr>=1.3.23" not in requirements
 
 
 def test_docs_use_quoted_current_funasr_install_commands():
@@ -30,10 +31,11 @@ def test_docs_use_quoted_current_funasr_install_commands():
         assert "funasr>=1.3.0" not in text
         assert "funasr>=1.3.3" not in text
         assert "funasr>=1.3.19" not in text
+        assert "funasr>=1.3.23" not in text
         assert not re.search(r"pip install funasr>=", text)
 
-    assert '"funasr>=1.3.23"' in (ROOT / "README.md").read_text()
-    assert (ROOT / "examples/README.md").read_text().count('"funasr>=1.3.23"') == 2
+    assert '"funasr>=1.3.24"' in (ROOT / "README.md").read_text()
+    assert (ROOT / "examples/README.md").read_text().count('"funasr>=1.3.24"') == 2
 
 
 def test_docs_relative_markdown_links_point_to_existing_files():


### PR DESCRIPTION
## Summary
- update Fun-ASR install commands and requirements to the newly published `funasr>=1.3.24`
- extend the release-floor regression test to reject the old 1.3.23 floor

## Tests
- python3 -m pytest -q tests/test_funasr_requirement.py
- python3 -m pytest -q tests/test_examples_smoke.py
- git diff --check
