### PR TITLE
Add Fun-ASR PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+## Summary
+
+- TODO
+
+## User impact
+
+Who benefits from this change, and what Fun-ASR workflow improves?
+
+## Model and runtime impact
+
+- [ ] No model behavior changes.
+- [ ] Affects Fun-ASR-Nano or Fun-ASR-MLT-Nano inference.
+- [ ] Affects streaming, vLLM, WebSocket, or client examples.
+- [ ] Affects GGUF / llama.cpp runtime assets or docs.
+- [ ] Affects Hugging Face, ModelScope, or model-card routing.
+
+## Validation
+
+- [ ] I ran the relevant tests or commands:
+- [ ] I checked changed README/docs/model links.
+- [ ] I verified affected model, runtime, or example behavior with a small audio sample when applicable.
+
+## Screenshots, logs, or transcripts
+
+Add command output, before/after transcripts, benchmark snippets, screenshots, or logs when they help reviewers understand the change.
+
+## Notes for reviewers
+
+Mention known limitations, skipped optional dependencies, or follow-up work.

--- a/tests/test_github_templates.py
+++ b/tests/test_github_templates.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_pull_request_template_keeps_model_validation_visible():
+    template = ROOT / ".github" / "PULL_REQUEST_TEMPLATE.md"
+    assert template.exists()
+
+    text = template.read_text()
+    required = [
+        "Summary",
+        "User impact",
+        "Model and runtime impact",
+        "Validation",
+        "Screenshots, logs, or transcripts",
+    ]
+    for marker in required:
+        assert marker in text


### PR DESCRIPTION
## Summary
- add a Fun-ASR pull request template focused on user impact, model/runtime scope, validation, and transcripts/logs
- add a lightweight regression test so the template stays present and actionable

## Why
Fun-ASR changes often touch model behavior, streaming/vLLM paths, GGUF/runtime docs, or HF/ModelScope routing. The PR template makes reviewers ask for the right evidence up front, reducing back-and-forth and helping external contributors land focused changes.

## Validation
- `python3 -m pytest -q tests/test_github_templates.py tests/test_funasr_requirement.py tests/test_examples_smoke.py tests/test_serve_realtime_ws_static.py`
- `python3 -m py_compile demo_vllm.py decode.py serve_realtime_ws.py examples/quickstart.py examples/direct_inference.py`
- `git diff --cached --check`
