### PR TITLE
docs: surface FunASR 1.3.27 for Nano serving

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Online Experience:
 
 # What's New 🔥
 
+- 2026/07: **FunASR 1.3.27 improves Fun-ASR-Nano serving reliability** — after a vLLM startup failure, the OpenAI-compatible server reuses one cached fallback `AutoModel` instead of rebuilding it; partial vLLM/VAD initialization remains retryable. Install with `pip install -U "funasr==1.3.27"`. [Release notes](https://github.com/modelscope/FunASR/releases/tag/v1.3.27) · [deployment guide](https://www.funasr.com/en/blog/funasr-v1-3-27-language-metadata-vllm-fallback.html) · [PyPI](https://pypi.org/project/funasr/1.3.27/)
 - 2026/07: **Native Hugging Face Transformers integration is in review** — track [transformers#46180](https://github.com/huggingface/transformers/pull/46180) for the Fun-ASR-Nano model implementation. Until it lands in an official Transformers release, use the FunASR, [vLLM](docs/vllm_guide.md), or [llama.cpp / GGUF](./runtime/llama.cpp/) paths below for runnable inference.
 - 2026/06: **Fun-ASR-Nano on llama.cpp / GGUF** — run it on CPU/edge as a single self-contained binary (whisper.cpp-style), built-in VAD, no Python at runtime. Quantized models down to ~484 MB. [runtime/llama.cpp/](./runtime/llama.cpp/) · [Releases](https://github.com/FunAudioLLM/Fun-ASR/releases) · [Nano GGUF](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-GGUF) · [FSMN-VAD GGUF](https://huggingface.co/FunAudioLLM/fsmn-vad-GGUF)
 - 2026/05: **vLLM Inference Engine** — native high-throughput batch (3-5x faster) + WebSocket real-time streaming service. See [vLLM Guide](docs/vllm_guide.md).

--- a/README_ja.md
+++ b/README_ja.md
@@ -2,6 +2,8 @@
 
 「[简体中文](README_zh.md)」|「[English](README.md)」|「日本語」
 
+> **FunASR 1.3.27:** vLLM の起動に失敗した場合、OpenAI 互換サーバーはフォールバック用の `AutoModel` を一度だけ構築してキャッシュし、再利用します。vLLM/VAD の初期化が途中で失敗した場合は再試行できます。`pip install -U "funasr==1.3.27"` でインストールしてください。[リリースノート](https://github.com/modelscope/FunASR/releases/tag/v1.3.27) · [デプロイガイド](https://www.funasr.com/en/blog/funasr-v1-3-27-language-metadata-vllm-fallback.html) · [PyPI](https://pypi.org/project/funasr/1.3.27/)
+
 Fun-ASRは通義実験室が開発したエンドツーエンド音声認識モデルファミリーです。チェックポイントごとに対応範囲が異なり、Fun-ASR-Nano-2512は中・英・日と中国語方言・地域アクセント、Fun-ASR-MLT-Nano-2512は31言語に対応します。どちらもFunASRから推論・配信できます。
 
 <div align="center">

--- a/README_ko.md
+++ b/README_ko.md
@@ -2,6 +2,8 @@
 
 「[简体中文](README_zh.md)」|「[English](README.md)」|「[日本語](README_ja.md)」|「한국어」
 
+> **FunASR 1.3.27:** vLLM 시작에 실패하면 OpenAI 호환 서버가 폴백 `AutoModel`을 한 번만 생성해 캐시하고 재사용합니다. vLLM/VAD 초기화가 중간에 실패한 경우에는 다시 시도할 수 있습니다. `pip install -U "funasr==1.3.27"`로 설치하세요. [릴리스 노트](https://github.com/modelscope/FunASR/releases/tag/v1.3.27) · [배포 가이드](https://www.funasr.com/en/blog/funasr-v1-3-27-language-metadata-vllm-fallback.html) · [PyPI](https://pypi.org/project/funasr/1.3.27/)
+
 Fun-ASR는 통의(Tongyi) 실험실에서 개발한 엔드투엔드 음성 인식 모델 제품군입니다. 체크포인트별 지원 범위가 다릅니다. Fun-ASR-Nano-2512는 중국어·영어·일본어와 중국어 방언·지역 억양을 지원하고, Fun-ASR-MLT-Nano-2512는 31개 언어를 지원합니다. 두 체크포인트 모두 FunASR에서 추론과 서빙에 사용할 수 있습니다.
 
 <div align="center">

--- a/README_zh.md
+++ b/README_zh.md
@@ -36,6 +36,7 @@ Fun-ASR 是通义实验室推出的端到端语音识别模型家族，不同 ch
 
 # 最新动态 🔥
 
+- 2026/07：**FunASR 1.3.27 提升 Fun-ASR-Nano 服务可靠性** — vLLM 启动失败后，OpenAI 兼容服务会复用同一个 `AutoModel` 缓存回退，而不是重复构建模型；vLLM/VAD 部分初始化失败后仍可重试。安装命令：`pip install -U "funasr==1.3.27"`。[发布说明](https://github.com/modelscope/FunASR/releases/tag/v1.3.27) · [部署指南](https://www.funasr.com/blog/funasr-v1-3-27-language-metadata-vllm-fallback.html) · [PyPI](https://pypi.org/project/funasr/1.3.27/)
 - 2026/07: **Hugging Face Transformers 原生集成正在审查中** — Fun-ASR-Nano 模型实现进度见 [transformers#46180](https://github.com/huggingface/transformers/pull/46180)。在正式进入 Transformers release 前，请使用下方 FunASR、[vLLM](docs/vllm_guide_zh.md) 或 [llama.cpp / GGUF](./runtime/llama.cpp/) 路径完成可运行推理。
 - 2026/06: **Fun-ASR-Nano on llama.cpp / GGUF** — 支持在 CPU/边缘设备上以单个自包含二进制运行（类似 whisper.cpp），内置 VAD，运行时无需 Python。量化模型最小约 484 MB。[runtime/llama.cpp/](./runtime/llama.cpp/) · [Releases](https://github.com/FunAudioLLM/Fun-ASR/releases) · [Nano GGUF](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-GGUF) · [FSMN-VAD GGUF](https://huggingface.co/FunAudioLLM/fsmn-vad-GGUF)
 - 2026/05: **vLLM 推理引擎** — 原生高吞吐批量推理（3-5 倍加速）+ WebSocket 实时流式服务。参见 [vLLM 指南](docs/vllm_guide.md)。

--- a/tests/test_funasr_requirement.py
+++ b/tests/test_funasr_requirement.py
@@ -38,6 +38,25 @@ def test_docs_use_quoted_current_funasr_install_commands():
     assert (ROOT / "examples/README.md").read_text().count('"funasr>=1.3.26"') == 2
 
 
+def test_readmes_surface_funasr_1327_nano_serving_release():
+    required = [
+        "funasr==1.3.27",
+        "AutoModel",
+        "vLLM",
+        "https://github.com/modelscope/FunASR/releases/tag/v1.3.27",
+    ]
+    guides = {
+        "README.md": "https://www.funasr.com/en/blog/funasr-v1-3-27-language-metadata-vllm-fallback.html",
+        "README_zh.md": "https://www.funasr.com/blog/funasr-v1-3-27-language-metadata-vllm-fallback.html",
+        "README_ja.md": "https://www.funasr.com/en/blog/funasr-v1-3-27-language-metadata-vllm-fallback.html",
+        "README_ko.md": "https://www.funasr.com/en/blog/funasr-v1-3-27-language-metadata-vllm-fallback.html",
+    }
+    for relpath, guide in guides.items():
+        text = (ROOT / relpath).read_text()
+        for marker in [*required, guide]:
+            assert marker in text, f"{relpath} is missing {marker}"
+
+
 def test_docs_relative_markdown_links_point_to_existing_files():
     link_pattern = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
     for relpath in DOCS:


### PR DESCRIPTION
## Summary

- add the FunASR 1.3.27 Nano-serving reliability update to English and Chinese release news
- add equivalent first-viewport callouts to Japanese and Korean READMEs
- guard all localized entry points with release, deployment-guide, and install markers

## Impact

Users reaching Fun-ASR directly can discover the cached `AutoModel` fallback and retry-safe vLLM/VAD initialization instead of remaining on 1.3.26 guidance. Existing compatibility floors and model code are unchanged.

## Validation

- `python3 -m pytest -q tests` (19 passed)
- `python3 -m compileall -q tests`
- `git diff --check`
- release, PyPI, and bilingual deployment links returned HTTP 200
