### PR TITLE
docs: use QwenAudio canonical repository links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for your interest in contributing to Fun-ASR!
 
 ### Reporting Bugs
 
-1. Check if the issue already exists in [Issues](https://github.com/FunAudioLLM/Fun-ASR/issues)
+1. Check if the issue already exists in [Issues](https://github.com/QwenAudio/Fun-ASR/issues)
 2. If not, open a new issue with:
    - Your environment (OS, Python, PyTorch, FunASR version)
    - Steps to reproduce
@@ -14,7 +14,7 @@ Thank you for your interest in contributing to Fun-ASR!
 
 ### Suggesting Features
 
-Open a [Discussion](https://github.com/FunAudioLLM/Fun-ASR/discussions) or Issue describing your use case and proposed solution.
+Open a [Discussion](https://github.com/QwenAudio/Fun-ASR/discussions) or Issue describing your use case and proposed solution.
 
 ### Submitting Code
 
@@ -35,7 +35,7 @@ Open a [Discussion](https://github.com/FunAudioLLM/Fun-ASR/discussions) or Issue
 ## Development Setup
 
 ```bash
-git clone https://github.com/FunAudioLLM/Fun-ASR.git
+git clone https://github.com/QwenAudio/Fun-ASR.git
 cd Fun-ASR
 pip install -r requirements.txt
 ```

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Model repositories: **Fun-ASR-Nano** ([ModelScope](https://www.modelscope.cn/mod
 Online Experience:
 [ModelScope Community Space](https://modelscope.cn/studios/FunAudioLLM/Fun-ASR-Nano), [huggingface space](https://huggingface.co/spaces/FunAudioLLM/Fun-ASR-Nano)
 
-[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/FunAudioLLM/Fun-ASR/blob/main/examples/colab/fun_asr_nano_quickstart.ipynb)
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/QwenAudio/Fun-ASR/blob/main/examples/colab/fun_asr_nano_quickstart.ipynb)
 
 [Runnable examples](examples/README.md) cover quickstart inference, direct inference, speaker diarization, vLLM batch inference, and the streaming SDK.
 
@@ -41,7 +41,7 @@ Online Experience:
 - 2026/07: **FunASR 1.3.28 hardens real-time transcription** — the WebSocket server now preserves stable final text when a VAD-locked final pass regresses, decodes short tails on `STOP`, and handles closed connections explicitly. Install with `pip install -U "funasr==1.3.28"`. [Release notes](https://github.com/modelscope/FunASR/releases/tag/v1.3.28) · [deployment guide](https://www.funasr.com/en/blog/funasr-v1-3-28-realtime-websocket-subtitles.html) · [PyPI](https://pypi.org/project/funasr/1.3.28/)
 - 2026/07: **FunASR 1.3.27 improves Fun-ASR-Nano serving reliability** — after a vLLM startup failure, the OpenAI-compatible server reuses one cached fallback `AutoModel` instead of rebuilding it; partial vLLM/VAD initialization remains retryable. Install with `pip install -U "funasr==1.3.27"`. [Release notes](https://github.com/modelscope/FunASR/releases/tag/v1.3.27) · [deployment guide](https://www.funasr.com/en/blog/funasr-v1-3-27-language-metadata-vllm-fallback.html) · [PyPI](https://pypi.org/project/funasr/1.3.27/)
 - 2026/07: **Native Hugging Face Transformers integration is in review** — track [transformers#46180](https://github.com/huggingface/transformers/pull/46180) for the Fun-ASR-Nano model implementation. Until it lands in an official Transformers release, use the FunASR, [vLLM](docs/vllm_guide.md), or [llama.cpp / GGUF](./runtime/llama.cpp/) paths below for runnable inference.
-- 2026/06: **Fun-ASR-Nano on llama.cpp / GGUF** — run it on CPU/edge as a single self-contained binary (whisper.cpp-style), built-in VAD, no Python at runtime. Quantized models down to ~484 MB. [runtime/llama.cpp/](./runtime/llama.cpp/) · [Releases](https://github.com/FunAudioLLM/Fun-ASR/releases) · [Nano GGUF](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-GGUF) · [FSMN-VAD GGUF](https://huggingface.co/FunAudioLLM/fsmn-vad-GGUF)
+- 2026/06: **Fun-ASR-Nano on llama.cpp / GGUF** — run it on CPU/edge as a single self-contained binary (whisper.cpp-style), built-in VAD, no Python at runtime. Quantized models down to ~484 MB. [runtime/llama.cpp/](./runtime/llama.cpp/) · [Releases](https://github.com/QwenAudio/Fun-ASR/releases) · [Nano GGUF](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-GGUF) · [FSMN-VAD GGUF](https://huggingface.co/FunAudioLLM/fsmn-vad-GGUF)
 - 2026/05: **vLLM Inference Engine** — native high-throughput batch (3-5x faster) + WebSocket real-time streaming service. See [vLLM Guide](docs/vllm_guide.md).
 - 2026/05: The FunASR pipeline can combine Fun-ASR-Nano with separate FSMN-VAD, CAM++, and punctuation models to produce per-sentence speaker labels. Diarization is not a native output of the Nano checkpoint. Requires installing FunASR from source: `pip install git+https://github.com/modelscope/FunASR.git`
 - 2025/12: [Fun-ASR-Nano-2512](https://modelscope.cn/models/FunAudioLLM/Fun-ASR-Nano-2512) was released for Chinese, English, Japanese, and Chinese dialects and accents. For 31-language recognition, use the separate [Fun-ASR-MLT-Nano-2512](https://modelscope.cn/models/FunAudioLLM/Fun-ASR-MLT-Nano-2512) checkpoint.
@@ -61,7 +61,7 @@ Online Experience:
 # Environment Setup 🐍
 
 ```shell
-git clone https://github.com/FunAudioLLM/Fun-ASR.git
+git clone https://github.com/QwenAudio/Fun-ASR.git
 cd Fun-ASR
 pip install -r requirements.txt
 ```
@@ -71,7 +71,7 @@ pip install -r requirements.txt
 # Capability boundaries
 
 - [ ] Reliable checkpoint-native timestamps
-  > The released Fun-ASR-Nano `model.pt` checkpoint does not include trained `ctc_decoder.*` / `ctc.*` weights. Any timestamp output is therefore not reliable. For accurate character-level timestamps, use Paraformer, for example `AutoModel(model="paraformer-zh", vad_model="fsmn-vad", ...)`. See [issue #106](https://github.com/FunAudioLLM/Fun-ASR/issues/106).
+  > The released Fun-ASR-Nano `model.pt` checkpoint does not include trained `ctc_decoder.*` / `ctc.*` weights. Any timestamp output is therefore not reliable. For accurate character-level timestamps, use Paraformer, for example `AutoModel(model="paraformer-zh", vad_model="fsmn-vad", ...)`. See [issue #106](https://github.com/QwenAudio/Fun-ASR/issues/106).
 - [ ] Checkpoint-native speaker diarization
   > Fun-ASR-Nano and Fun-ASR-MLT-Nano do not emit speaker labels by themselves. Compose them in FunASR with the separate `fsmn-vad` and `cam++` models, as shown below.
 - [x] Model training
@@ -95,7 +95,7 @@ llama-funasr-cli --enc ./gguf/funasr-encoder-f16.gguf -m ./gguf/qwen3-0.6b-q8_0.
 hf download FunAudioLLM/fsmn-vad-GGUF --include "*.gguf" --local-dir ./gguf
 ```
 
-**Prebuilt binaries:** [Releases](https://github.com/FunAudioLLM/Fun-ASR/releases) · **Download & quickstart:** [funasr.com/llama-cpp](https://www.funasr.com/llama-cpp.html) · **GGUF:** [Nano encoder/LLM](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-GGUF) · [FSMN-VAD](https://huggingface.co/FunAudioLLM/fsmn-vad-GGUF) · **Docs & benchmarks:** [runtime/llama.cpp/](./runtime/llama.cpp/)
+**Prebuilt binaries:** [Releases](https://github.com/QwenAudio/Fun-ASR/releases) · **Download & quickstart:** [funasr.com/llama-cpp](https://www.funasr.com/llama-cpp.html) · **GGUF:** [Nano encoder/LLM](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-GGUF) · [FSMN-VAD](https://huggingface.co/FunAudioLLM/fsmn-vad-GGUF) · **Docs & benchmarks:** [runtime/llama.cpp/](./runtime/llama.cpp/)
 
 ### Using funasr for inference
 
@@ -372,7 +372,7 @@ We evaluated Fun-ASR against other state-of-the-art models on open-source benchm
 
 ## Remarkable Third-Party Work
 
-- **[Fun-ASR-vllm](https://github.com/yuekaizhang/Fun-ASR-vllm)** ([@yuekaizhang](https://github.com/yuekaizhang)) — a community vLLM implementation of Fun-ASR (~50% speedup over PyTorch), with batch inference and an NVIDIA Triton Inference Server integration for high-concurrency production deployment. See [#34](https://github.com/FunAudioLLM/Fun-ASR/issues/34).
+- **[Fun-ASR-vllm](https://github.com/yuekaizhang/Fun-ASR-vllm)** ([@yuekaizhang](https://github.com/yuekaizhang)) — a community vLLM implementation of Fun-ASR (~50% speedup over PyTorch), with batch inference and an NVIDIA Triton Inference Server integration for high-concurrency production deployment. See [#34](https://github.com/QwenAudio/Fun-ASR/issues/34).
 
 > Native vLLM support is also built in — see [vLLM High-Throughput Inference 🚀](#vllm-high-throughput-inference-) above for the `AutoModelVLLM` batch engine, the streaming SDK, and the WebSocket service.
 
@@ -383,15 +383,15 @@ Fun-ASR-Nano is part of the **FunAudioLLM** family:
 | Project | Description | Stars |
 |---------|-------------|-------|
 | [FunASR](https://github.com/modelscope/FunASR) | Industrial speech recognition toolkit — VAD, ASR, punctuation, diarization | [![](https://img.shields.io/github/stars/modelscope/FunASR?style=social)](https://github.com/modelscope/FunASR) |
-| [SenseVoice](https://github.com/FunAudioLLM/SenseVoice) | Multilingual speech understanding — ASR + emotion + audio events | [![](https://img.shields.io/github/stars/FunAudioLLM/SenseVoice?style=social)](https://github.com/FunAudioLLM/SenseVoice) |
-| [CosyVoice](https://github.com/FunAudioLLM/CosyVoice) | Natural speech generation — multi-language, zero-shot cloning | [![](https://img.shields.io/github/stars/FunAudioLLM/CosyVoice?style=social)](https://github.com/FunAudioLLM/CosyVoice) |
+| [SenseVoice](https://github.com/QwenAudio/SenseVoice) | Multilingual speech understanding — ASR + emotion + audio events | [![](https://img.shields.io/github/stars/QwenAudio/SenseVoice?style=social)](https://github.com/QwenAudio/SenseVoice) |
+| [CosyVoice](https://github.com/QwenAudio/CosyVoice) | Natural speech generation — multi-language, zero-shot cloning | [![](https://img.shields.io/github/stars/QwenAudio/CosyVoice?style=social)](https://github.com/QwenAudio/CosyVoice) |
 | [FunClip](https://github.com/modelscope/FunClip) | AI-powered video clipping with speech recognition | [![](https://img.shields.io/github/stars/modelscope/FunClip?style=social)](https://github.com/modelscope/FunClip) |
 
-<a href="https://star-history.com/#FunAudioLLM/Fun-ASR&modelscope/FunASR&FunAudioLLM/SenseVoice&Date">
+<a href="https://star-history.com/#QwenAudio/Fun-ASR&modelscope/FunASR&QwenAudio/SenseVoice&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=FunAudioLLM/Fun-ASR,modelscope/FunASR,FunAudioLLM/SenseVoice&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=FunAudioLLM/Fun-ASR,modelscope/FunASR,FunAudioLLM/SenseVoice&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=FunAudioLLM/Fun-ASR,modelscope/FunASR,FunAudioLLM/SenseVoice&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=QwenAudio/Fun-ASR,modelscope/FunASR,QwenAudio/SenseVoice&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=QwenAudio/Fun-ASR,modelscope/FunASR,QwenAudio/SenseVoice&type=Date" />
+    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=QwenAudio/Fun-ASR,modelscope/FunASR,QwenAudio/SenseVoice&type=Date" />
   </picture>
 </a>
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -25,7 +25,7 @@ Fun-ASRは通義実験室が開発したエンドツーエンド音声認識モ�
 オンラインデモ：
 [ModelScope Space](https://modelscope.cn/studios/FunAudioLLM/Fun-ASR-Nano)、[HuggingFace Space](https://huggingface.co/spaces/FunAudioLLM/Fun-ASR-Nano)
 
-[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/FunAudioLLM/Fun-ASR/blob/main/examples/colab/fun_asr_nano_quickstart.ipynb)
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/QwenAudio/Fun-ASR/blob/main/examples/colab/fun_asr_nano_quickstart.ipynb)
 
 [実行可能なサンプル](examples/README.md) では、クイックスタート推論、直接推論、話者分離、vLLM バッチ推論、Streaming SDK を確認できます。
 
@@ -55,7 +55,7 @@ CPU/エッジ端末では、Fun-ASR-Nano を llama.cpp / GGUF ランタイムで
 # 環境構築 🐍
 
 ```shell
-git clone https://github.com/FunAudioLLM/Fun-ASR.git
+git clone https://github.com/QwenAudio/Fun-ASR.git
 cd Fun-ASR
 pip install -r requirements.txt
 ```
@@ -64,7 +64,7 @@ pip install -r requirements.txt
 
 # 機能の境界
 
-- **タイムスタンプ**：公開済みNano checkpointには学習済みCTC重みが含まれないため、checkpoint由来の文字単位タイムスタンプは信頼できません。正確な文字単位タイムスタンプにはParaformerを使用してください（[issue #106](https://github.com/FunAudioLLM/Fun-ASR/issues/106)）。
+- **タイムスタンプ**：公開済みNano checkpointには学習済みCTC重みが含まれないため、checkpoint由来の文字単位タイムスタンプは信頼できません。正確な文字単位タイムスタンプにはParaformerを使用してください（[issue #106](https://github.com/QwenAudio/Fun-ASR/issues/106)）。
 - **話者分離**：Nano/MLT checkpoint自体は話者ラベルを出力しません。FunASRで`fsmn-vad`と`cam++`を組み合わせます。
 
 # 使い方 🛠️
@@ -143,8 +143,8 @@ Fun-ASR-Nanoは **FunAudioLLM** ファミリーの一員です：
 | プロジェクト | 説明 | Stars |
 |-------------|------|-------|
 | [FunASR](https://github.com/modelscope/FunASR) | 産業用音声認識ツールキット — VAD、ASR、句読点、話者分離 | [![](https://img.shields.io/github/stars/modelscope/FunASR?style=social)](https://github.com/modelscope/FunASR) |
-| [SenseVoice](https://github.com/FunAudioLLM/SenseVoice) | 超高速ASR + 感情認識 + 音声イベント検出 | [![](https://img.shields.io/github/stars/FunAudioLLM/SenseVoice?style=social)](https://github.com/FunAudioLLM/SenseVoice) |
-| [CosyVoice](https://github.com/FunAudioLLM/CosyVoice) | 自然音声生成 — 多言語、ゼロショットクローニング | [![](https://img.shields.io/github/stars/FunAudioLLM/CosyVoice?style=social)](https://github.com/FunAudioLLM/CosyVoice) |
+| [SenseVoice](https://github.com/QwenAudio/SenseVoice) | 超高速ASR + 感情認識 + 音声イベント検出 | [![](https://img.shields.io/github/stars/QwenAudio/SenseVoice?style=social)](https://github.com/QwenAudio/SenseVoice) |
+| [CosyVoice](https://github.com/QwenAudio/CosyVoice) | 自然音声生成 — 多言語、ゼロショットクローニング | [![](https://img.shields.io/github/stars/QwenAudio/CosyVoice?style=social)](https://github.com/QwenAudio/CosyVoice) |
 | [FunClip](https://github.com/modelscope/FunClip) | AI音声認識による動画クリッピング | [![](https://img.shields.io/github/stars/modelscope/FunClip?style=social)](https://github.com/modelscope/FunClip) |
 
 ## ライセンス

--- a/README_ko.md
+++ b/README_ko.md
@@ -25,7 +25,7 @@ Fun-ASR는 통의(Tongyi) 실험실에서 개발한 엔드투엔드 음성 인�
 온라인 체험:
 [ModelScope Space](https://modelscope.cn/studios/FunAudioLLM/Fun-ASR-Nano), [HuggingFace Space](https://huggingface.co/spaces/FunAudioLLM/Fun-ASR-Nano)
 
-[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/FunAudioLLM/Fun-ASR/blob/main/examples/colab/fun_asr_nano_quickstart.ipynb)
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/QwenAudio/Fun-ASR/blob/main/examples/colab/fun_asr_nano_quickstart.ipynb)
 
 [실행 가능한 예제](examples/README.md)는 quickstart 추론, 직접 추론, 화자 분리, vLLM 배치 추론, Streaming SDK를 다룹니다.
 
@@ -54,7 +54,7 @@ CPU/엣지 환경에서는 Fun-ASR-Nano를 llama.cpp / GGUF 런타임으로 단�
 # 환경 설정 🐍
 
 ```shell
-git clone https://github.com/FunAudioLLM/Fun-ASR.git
+git clone https://github.com/QwenAudio/Fun-ASR.git
 cd Fun-ASR
 pip install -r requirements.txt
 ```
@@ -63,7 +63,7 @@ pip install -r requirements.txt
 
 # 기능 범위
 
-- **타임스탬프**: 공개된 Nano 체크포인트에는 학습된 CTC 가중치가 없어 체크포인트 기반 문자 단위 타임스탬프를 신뢰할 수 없습니다. 정확한 문자 단위 타임스탬프에는 Paraformer를 사용하세요([issue #106](https://github.com/FunAudioLLM/Fun-ASR/issues/106)).
+- **타임스탬프**: 공개된 Nano 체크포인트에는 학습된 CTC 가중치가 없어 체크포인트 기반 문자 단위 타임스탬프를 신뢰할 수 없습니다. 정확한 문자 단위 타임스탬프에는 Paraformer를 사용하세요([issue #106](https://github.com/QwenAudio/Fun-ASR/issues/106)).
 - **화자 분리**: Nano/MLT 체크포인트 자체는 화자 레이블을 출력하지 않습니다. FunASR에서 `fsmn-vad`와 `cam++`를 조합합니다.
 
 # 사용법 🛠️
@@ -127,8 +127,8 @@ Fun-ASR-Nano는 **FunAudioLLM** 패밀리의 일원입니다:
 | 프로젝트 | 설명 | Stars |
 |----------|------|-------|
 | [FunASR](https://github.com/modelscope/FunASR) | 산업용 음성 인식 툴킷 — VAD, ASR, 구두점, 화자 분리 | [![](https://img.shields.io/github/stars/modelscope/FunASR?style=social)](https://github.com/modelscope/FunASR) |
-| [SenseVoice](https://github.com/FunAudioLLM/SenseVoice) | 초고속 ASR + 감정 인식 + 오디오 이벤트 감지 | [![](https://img.shields.io/github/stars/FunAudioLLM/SenseVoice?style=social)](https://github.com/FunAudioLLM/SenseVoice) |
-| [CosyVoice](https://github.com/FunAudioLLM/CosyVoice) | 자연 음성 생성 — 다국어, 제로샷 클로닝 | [![](https://img.shields.io/github/stars/FunAudioLLM/CosyVoice?style=social)](https://github.com/FunAudioLLM/CosyVoice) |
+| [SenseVoice](https://github.com/QwenAudio/SenseVoice) | 초고속 ASR + 감정 인식 + 오디오 이벤트 감지 | [![](https://img.shields.io/github/stars/QwenAudio/SenseVoice?style=social)](https://github.com/QwenAudio/SenseVoice) |
+| [CosyVoice](https://github.com/QwenAudio/CosyVoice) | 자연 음성 생성 — 다국어, 제로샷 클로닝 | [![](https://img.shields.io/github/stars/QwenAudio/CosyVoice?style=social)](https://github.com/QwenAudio/CosyVoice) |
 | [FunClip](https://github.com/modelscope/FunClip) | AI 음성 인식 기반 비디오 클리핑 | [![](https://img.shields.io/github/stars/modelscope/FunClip?style=social)](https://github.com/modelscope/FunClip) |
 
 ## 라이선스

--- a/README_zh.md
+++ b/README_zh.md
@@ -39,7 +39,7 @@ Fun-ASR 是通义实验室推出的端到端语音识别模型家族，不同 ch
 - 2026/07：**FunASR 1.3.28 提升实时转写稳定性** — WebSocket 服务会在 VAD 锁定的最终解码发生退化时保留稳定文本，在收到 `STOP` 后解码短尾音频，并显式处理连接关闭。安装命令：`pip install -U "funasr==1.3.28"`。[发布说明](https://github.com/modelscope/FunASR/releases/tag/v1.3.28) · [部署指南](https://www.funasr.com/blog/funasr-v1-3-28-realtime-websocket-subtitles.html) · [PyPI](https://pypi.org/project/funasr/1.3.28/)
 - 2026/07：**FunASR 1.3.27 提升 Fun-ASR-Nano 服务可靠性** — vLLM 启动失败后，OpenAI 兼容服务会复用同一个 `AutoModel` 缓存回退，而不是重复构建模型；vLLM/VAD 部分初始化失败后仍可重试。安装命令：`pip install -U "funasr==1.3.27"`。[发布说明](https://github.com/modelscope/FunASR/releases/tag/v1.3.27) · [部署指南](https://www.funasr.com/blog/funasr-v1-3-27-language-metadata-vllm-fallback.html) · [PyPI](https://pypi.org/project/funasr/1.3.27/)
 - 2026/07: **Hugging Face Transformers 原生集成正在审查中** — Fun-ASR-Nano 模型实现进度见 [transformers#46180](https://github.com/huggingface/transformers/pull/46180)。在正式进入 Transformers release 前，请使用下方 FunASR、[vLLM](docs/vllm_guide_zh.md) 或 [llama.cpp / GGUF](./runtime/llama.cpp/) 路径完成可运行推理。
-- 2026/06: **Fun-ASR-Nano on llama.cpp / GGUF** — 支持在 CPU/边缘设备上以单个自包含二进制运行（类似 whisper.cpp），内置 VAD，运行时无需 Python。量化模型最小约 484 MB。[runtime/llama.cpp/](./runtime/llama.cpp/) · [Releases](https://github.com/FunAudioLLM/Fun-ASR/releases) · [Nano GGUF](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-GGUF) · [FSMN-VAD GGUF](https://huggingface.co/FunAudioLLM/fsmn-vad-GGUF)
+- 2026/06: **Fun-ASR-Nano on llama.cpp / GGUF** — 支持在 CPU/边缘设备上以单个自包含二进制运行（类似 whisper.cpp），内置 VAD，运行时无需 Python。量化模型最小约 484 MB。[runtime/llama.cpp/](./runtime/llama.cpp/) · [Releases](https://github.com/QwenAudio/Fun-ASR/releases) · [Nano GGUF](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-GGUF) · [FSMN-VAD GGUF](https://huggingface.co/FunAudioLLM/fsmn-vad-GGUF)
 - 2026/05: **vLLM 推理引擎** — 原生高吞吐批量推理（3-5 倍加速）+ WebSocket 实时流式服务。参见 [vLLM 指南](docs/vllm_guide.md)。
 - 2026/05: FunASR pipeline 可将 Fun-ASR-Nano 与独立的 FSMN-VAD、CAM++ 和标点模型组合，生成逐句说话人标签；说话人分离并非 Nano checkpoint 的原生输出。需从源码安装 FunASR：`pip install git+https://github.com/modelscope/FunASR.git`
 - 2025/12: [Fun-ASR-Nano-2512](https://modelscope.cn/models/FunAudioLLM/Fun-ASR-Nano-2512) 上线，支持中文、英文、日文及中文方言和地域口音。31 语种识别请使用独立的 [Fun-ASR-MLT-Nano-2512](https://modelscope.cn/models/FunAudioLLM/Fun-ASR-MLT-Nano-2512) checkpoint。
@@ -59,7 +59,7 @@ Fun-ASR 是通义实验室推出的端到端语音识别模型家族，不同 ch
 # 环境安装 🐍
 
 ```shell
-git clone https://github.com/FunAudioLLM/Fun-ASR.git
+git clone https://github.com/QwenAudio/Fun-ASR.git
 cd Fun-ASR
 pip install -r requirements.txt
 ```
@@ -69,7 +69,7 @@ pip install -r requirements.txt
 # 能力边界
 
 - [ ] 可靠的 checkpoint 原生时间戳
-  > 当前发布的 Fun-ASR-Nano `model.pt` checkpoint 不包含已训练的 `ctc_decoder.*` / `ctc.*` 权重，因此其时间戳输出并不可靠。需要准确的字级时间戳时，请改用 Paraformer，例如 `AutoModel(model="paraformer-zh", vad_model="fsmn-vad", ...)`。详情见 [issue #106](https://github.com/FunAudioLLM/Fun-ASR/issues/106)。
+  > 当前发布的 Fun-ASR-Nano `model.pt` checkpoint 不包含已训练的 `ctc_decoder.*` / `ctc.*` 权重，因此其时间戳输出并不可靠。需要准确的字级时间戳时，请改用 Paraformer，例如 `AutoModel(model="paraformer-zh", vad_model="fsmn-vad", ...)`。详情见 [issue #106](https://github.com/QwenAudio/Fun-ASR/issues/106)。
 - [ ] checkpoint 原生说话人分离
   > Fun-ASR-Nano 和 Fun-ASR-MLT-Nano 本身不输出说话人标签；需在 FunASR 中组合独立的 `fsmn-vad` 与 `cam++` 模型。
 - [x] 支持模型训练
@@ -93,7 +93,7 @@ llama-funasr-cli --enc ./gguf/funasr-encoder-f16.gguf -m ./gguf/qwen3-0.6b-q8_0.
 hf download FunAudioLLM/fsmn-vad-GGUF --include "*.gguf" --local-dir ./gguf
 ```
 
-**预编译二进制：** [Releases](https://github.com/FunAudioLLM/Fun-ASR/releases) · **下载与快速开始：** [funasr.com/llama-cpp](https://www.funasr.com/llama-cpp.html) · **GGUF：** [Nano encoder/LLM](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-GGUF) · [FSMN-VAD](https://huggingface.co/FunAudioLLM/fsmn-vad-GGUF) · **文档与 benchmark：** [runtime/llama.cpp/](./runtime/llama.cpp/)
+**预编译二进制：** [Releases](https://github.com/QwenAudio/Fun-ASR/releases) · **下载与快速开始：** [funasr.com/llama-cpp](https://www.funasr.com/llama-cpp.html) · **GGUF：** [Nano encoder/LLM](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-GGUF) · [FSMN-VAD](https://huggingface.co/FunAudioLLM/fsmn-vad-GGUF) · **文档与 benchmark：** [runtime/llama.cpp/](./runtime/llama.cpp/)
 
 ### 使用 funasr 推理
 
@@ -223,7 +223,7 @@ if __name__ == "__main__":
 
 ## 优秀三方工作
 
-- **[Fun-ASR-vllm](https://github.com/yuekaizhang/Fun-ASR-vllm)**（[@yuekaizhang](https://github.com/yuekaizhang)）— 社区实现的 Fun-ASR vLLM 方案，支持批量推理和 NVIDIA Triton Inference Server 高并发部署。参见 [#34](https://github.com/FunAudioLLM/Fun-ASR/issues/34)。
+- **[Fun-ASR-vllm](https://github.com/yuekaizhang/Fun-ASR-vllm)**（[@yuekaizhang](https://github.com/yuekaizhang)）— 社区实现的 Fun-ASR vLLM 方案，支持批量推理和 NVIDIA Triton Inference Server 高并发部署。参见 [#34](https://github.com/QwenAudio/Fun-ASR/issues/34)。
 
 > Fun-ASR 也已内置原生 vLLM 支持，包括 `AutoModelVLLM` 批量推理、Streaming SDK 和 WebSocket 服务；请参考 [vLLM 中文指南](docs/vllm_guide_zh.md) 与 [可运行示例脚本](examples/README.md)。
 

--- a/examples/colab/fun_asr_nano_quickstart.ipynb
+++ b/examples/colab/fun_asr_nano_quickstart.ipynb
@@ -24,10 +24,10 @@
         "\n",
         "**End-to-end speech recognition large model** — Fun-ASR-Nano-2512 supports Chinese, English, Japanese, and Chinese dialect/accent speech. For 31-language ASR, use the separate Fun-ASR-MLT-Nano-2512 checkpoint.\n",
         "\n",
-        "[![GitHub](https://img.shields.io/github/stars/FunAudioLLM/Fun-ASR?style=social)](https://github.com/FunAudioLLM/Fun-ASR)\n",
+        "[![GitHub](https://img.shields.io/github/stars/QwenAudio/Fun-ASR?style=social)](https://github.com/QwenAudio/Fun-ASR)\n",
         "[![Website](https://img.shields.io/badge/website-funasr.com-blue)](https://www.funasr.com)\n",
         "\n",
-        "⭐ **If you find this useful, please star the repo!** → [github.com/FunAudioLLM/Fun-ASR](https://github.com/FunAudioLLM/Fun-ASR)\n",
+        "⭐ **If you find this useful, please star the repo!** → [github.com/QwenAudio/Fun-ASR](https://github.com/QwenAudio/Fun-ASR)\n",
         "\n",
         "---"
       ]
@@ -193,7 +193,7 @@
         "\n",
         "## Links\n",
         "\n",
-        "- **GitHub:** [FunAudioLLM/Fun-ASR](https://github.com/FunAudioLLM/Fun-ASR) ⭐\n",
+        "- **GitHub:** [QwenAudio/Fun-ASR](https://github.com/QwenAudio/Fun-ASR) ⭐\n",
         "- **Toolkit:** [modelscope/FunASR](https://github.com/modelscope/FunASR)\n",
         "- **Website:** [www.funasr.com](https://www.funasr.com)\n",
         "- **Nano model:** [HuggingFace](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-2512) · [ModelScope](https://modelscope.cn/models/FunAudioLLM/Fun-ASR-Nano-2512)\n",

--- a/tests/test_canonical_qwenaudio_links.py
+++ b/tests/test_canonical_qwenaudio_links.py
@@ -1,0 +1,74 @@
+import re
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+LEGACY_GITHUB_REPO = re.compile(
+    r"FunAudioLLM/(?:CosyVoice|Fun-ASR|SenseVoice)(?![A-Za-z0-9_-])"
+)
+LEGACY_GITHUB_OWNER_URL = re.compile(
+    r"https://(?:github\.com|img\.shields\.io/github/stars)/FunAudioLLM/"
+)
+HUGGING_FACE_URL = re.compile(
+    r"https://huggingface\.co/(?:spaces/)?FunAudioLLM/[^\s)>'\"]+"
+)
+
+
+def _tracked_text_files():
+    result = subprocess.run(
+        ["git", "ls-files", "-z"],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+    )
+    for raw_path in result.stdout.split(b"\0"):
+        if not raw_path:
+            continue
+        path = ROOT / raw_path.decode()
+        try:
+            yield path, path.read_text(encoding="utf-8")
+        except (FileNotFoundError, UnicodeDecodeError, IsADirectoryError):
+            continue
+
+
+def test_legacy_owner_matcher_covers_repository_api_and_charts():
+    legacy_examples = (
+        "https://api.github.com/repos/FunAudioLLM/CosyVoice",
+        "https://api.star-history.com/svg?repos=FunAudioLLM/CosyVoice&type=Date",
+        "https://github.com/FunAudioLLM/CosyVoice",
+        "https://img.shields.io/github/stars/FunAudioLLM/CosyVoice",
+        "FunAudioLLM/Fun-ASR",
+        "FunAudioLLM/SenseVoice",
+    )
+    for text in legacy_examples:
+        without_hugging_face_urls = HUGGING_FACE_URL.sub("", text)
+        assert LEGACY_GITHUB_OWNER_URL.search(text) or LEGACY_GITHUB_REPO.search(
+            without_hugging_face_urls
+        )
+
+    allowed_examples = (
+        "https://huggingface.co/FunAudioLLM/CosyVoice",
+        "https://huggingface.co/spaces/FunAudioLLM/SenseVoice",
+        "FunAudioLLM/CosyVoice-300M",
+        "FunAudioLLM/Fun-ASR-Nano-2512",
+        "FunAudioLLM/SenseVoiceSmall",
+    )
+    for text in allowed_examples:
+        without_hugging_face_urls = HUGGING_FACE_URL.sub("", text)
+        assert not LEGACY_GITHUB_OWNER_URL.search(text)
+        assert not LEGACY_GITHUB_REPO.search(without_hugging_face_urls)
+
+
+def test_tracked_files_use_qwenaudio_for_canonical_github_repositories():
+    offenders = []
+    for path, text in _tracked_text_files():
+        if path.resolve() == Path(__file__).resolve():
+            continue
+        without_hugging_face_urls = HUGGING_FACE_URL.sub("", text)
+        if LEGACY_GITHUB_OWNER_URL.search(text) or LEGACY_GITHUB_REPO.search(
+            without_hugging_face_urls
+        ):
+            offenders.append(str(path.relative_to(ROOT)))
+
+    assert not offenders, "legacy GitHub repository owner in: " + ", ".join(offenders)

--- a/tests/test_funasr_requirement.py
+++ b/tests/test_funasr_requirement.py
@@ -38,18 +38,17 @@ def test_docs_use_quoted_current_funasr_install_commands():
     assert (ROOT / "examples/README.md").read_text().count('"funasr>=1.3.26"') == 2
 
 
-def test_readmes_surface_funasr_1327_nano_serving_release():
+def test_readmes_surface_funasr_1328_realtime_release():
     required = [
-        "funasr==1.3.27",
-        "AutoModel",
-        "vLLM",
-        "https://github.com/modelscope/FunASR/releases/tag/v1.3.27",
+        "funasr==1.3.28",
+        "STOP",
+        "https://github.com/modelscope/FunASR/releases/tag/v1.3.28",
     ]
     guides = {
-        "README.md": "https://www.funasr.com/en/blog/funasr-v1-3-27-language-metadata-vllm-fallback.html",
-        "README_zh.md": "https://www.funasr.com/blog/funasr-v1-3-27-language-metadata-vllm-fallback.html",
-        "README_ja.md": "https://www.funasr.com/en/blog/funasr-v1-3-27-language-metadata-vllm-fallback.html",
-        "README_ko.md": "https://www.funasr.com/en/blog/funasr-v1-3-27-language-metadata-vllm-fallback.html",
+        "README.md": "https://www.funasr.com/en/blog/funasr-v1-3-28-realtime-websocket-subtitles.html",
+        "README_zh.md": "https://www.funasr.com/blog/funasr-v1-3-28-realtime-websocket-subtitles.html",
+        "README_ja.md": "https://www.funasr.com/en/blog/funasr-v1-3-28-realtime-websocket-subtitles.html",
+        "README_ko.md": "https://www.funasr.com/en/blog/funasr-v1-3-28-realtime-websocket-subtitles.html",
     }
     for relpath, guide in guides.items():
         text = (ROOT / relpath).read_text()


### PR DESCRIPTION
## Summary

- update Fun-ASR repository, issue, release, clone, Colab, badge, star-history, SenseVoice, and CosyVoice links to the canonical `QwenAudio` GitHub owner
- preserve every Hugging Face and ModelScope `FunAudioLLM/*` model or Space identifier
- add a tracked-file regression guard for the GitHub owner migration
- refresh the stale release-surface test from FunASR 1.3.27 to the already published 1.3.28 realtime release

GitHub's API now reports this repository as `QwenAudio/Fun-ASR`; old owner URLs redirect but are no longer canonical.

## Validation

- `python3 -m pytest -q tests` (`20 passed`)
- canonical `git ls-remote` for `QwenAudio/Fun-ASR` returned the current `main` head
- repository scan found zero legacy GitHub owner URLs while retaining 48 Hugging Face namespace URLs
- `git diff --check`
