### PR TITLE
docs: fix vLLM service script paths

### DIFF
--- a/docs/vllm_guide.md
+++ b/docs/vllm_guide.md
@@ -36,11 +36,15 @@
 
 ```bash
 pip install "funasr>=1.3.26"
-pip install vllm>=0.12.0
+pip install "vllm>=0.12.0"
 pip install safetensors tiktoken websockets regex fastapi uvicorn python-multipart
 
-cd /path/to/FunASR && pip install -e .
+git clone --depth 1 https://github.com/modelscope/FunASR.git
+cd FunASR
+pip install -e .
 ```
+
+> This model repository does not vendor the service scripts used below. The runnable `demo_vllm.py`, `serve_vllm.py`, `serve_realtime_ws.py`, and clients are maintained in the [canonical FunASR example directory](https://github.com/modelscope/FunASR/tree/main/examples/industrial_data_pretraining/fun_asr_nano). Run the remaining shell commands from the FunASR clone created above.
 
 **Hardware**: GPU ≥ 8 GB VRAM, CUDA ≥ 11.8. 16 GB+ recommended.
 

--- a/docs/vllm_guide_zh.md
+++ b/docs/vllm_guide_zh.md
@@ -36,11 +36,15 @@
 
 ```bash
 pip install "funasr>=1.3.26"
-pip install vllm>=0.12.0
+pip install "vllm>=0.12.0"
 pip install safetensors tiktoken websockets regex fastapi uvicorn python-multipart
 
-cd /path/to/FunASR && pip install -e .
+git clone --depth 1 https://github.com/modelscope/FunASR.git
+cd FunASR
+pip install -e .
 ```
+
+> 当前模型仓库不内置下文使用的服务脚本。可运行的 `demo_vllm.py`、`serve_vllm.py`、`serve_realtime_ws.py` 与客户端统一维护在 [FunASR 主仓示例目录](https://github.com/modelscope/FunASR/tree/main/examples/industrial_data_pretraining/fun_asr_nano)。请在上面创建的 FunASR clone 中执行后续 shell 命令。
 
 **硬件**：GPU ≥ 8GB VRAM，CUDA ≥ 11.8。推荐 16GB+。
 

--- a/tests/test_examples_smoke.py
+++ b/tests/test_examples_smoke.py
@@ -83,3 +83,20 @@ class RunnableExamplesSmokeTest(unittest.TestCase):
             for link in required_links:
                 with self.subTest(readme=readme_path, link=link):
                     self.assertIn(link, readme)
+
+    def test_vllm_guides_clone_canonical_service_scripts_before_use(self):
+        script_dir = "examples/industrial_data_pretraining/fun_asr_nano"
+        required = [
+            "git clone --depth 1 https://github.com/modelscope/FunASR.git",
+            "https://github.com/modelscope/FunASR/tree/main/" + script_dir,
+            script_dir + "/serve_vllm.py",
+            script_dir + "/serve_realtime_ws.py",
+            'pip install "vllm>=0.12.0"',
+        ]
+        for relpath in ("docs/vllm_guide.md", "docs/vllm_guide_zh.md"):
+            text = (ROOT / relpath).read_text(encoding="utf-8")
+            for marker in required:
+                with self.subTest(guide=relpath, marker=marker):
+                    self.assertIn(marker, text)
+            self.assertNotIn("pip install vllm>=0.12.0", text)
+            self.assertLess(text.index("git clone --depth 1"), text.index(f"cd {script_dir}"))


### PR DESCRIPTION
## Summary
- explain that runnable vLLM service scripts live in the canonical `modelscope/FunASR` example directory
- clone that repository before the first referenced script command in both guides
- quote the vLLM version specifier so shells do not treat `>` as redirection
- add a regression contract for clone order and all referenced service paths

Closes #142

## Validation
- `python -m pytest tests -q` (22 passed)
- guide execution contract
- `git diff --check`