### PR TITLE
docs: replace retired homepage links

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Fun-ASR is a family of end-to-end speech recognition models from Tongyi Lab. Che
 
 <div align="center">
 <h4>
-<a href="https://funaudiollm.github.io/funasr"> Homepage </a>
+<a href="https://www.funasr.com/en/"> Homepage </a>
 ｜<a href="#core-features"> Core Features </a>
 ｜<a href="#performance-evaluation"> Performance Evaluation </a>
 ｜<a href="#environment-setup"> Environment Setup </a>

--- a/README_ja.md
+++ b/README_ja.md
@@ -12,7 +12,7 @@ Fun-ASRは通義実験室が開発したエンドツーエンド音声認識モ�
 
 <div align="center">
 <h4>
-<a href="https://funaudiollm.github.io/funasr"> ホームページ </a>
+<a href="https://www.funasr.com/en/"> ホームページ </a>
 ｜<a href="#主要機能"> 主要機能 </a>
 ｜<a href="#性能評価"> 性能評価 </a>
 ｜<a href="#環境構築"> 環境構築 </a>

--- a/README_ko.md
+++ b/README_ko.md
@@ -12,7 +12,7 @@ Fun-ASR는 통의(Tongyi) 실험실에서 개발한 엔드투엔드 음성 인�
 
 <div align="center">
 <h4>
-<a href="https://funaudiollm.github.io/funasr"> 홈페이지 </a>
+<a href="https://www.funasr.com/en/"> 홈페이지 </a>
 ｜<a href="#주요-기능"> 주요 기능 </a>
 ｜<a href="#성능-평가"> 성능 평가 </a>
 ｜<a href="#환경-설정"> 환경 설정 </a>

--- a/README_zh.md
+++ b/README_zh.md
@@ -10,7 +10,7 @@ Fun-ASR 是通义实验室推出的端到端语音识别模型家族，不同 ch
 
 <div align="center">
 <h4>
-<a href="https://funaudiollm.github.io/funasr"> Homepage </a>
+<a href="https://www.funasr.com/"> Homepage </a>
 ｜<a href="#核心特性"> 核心特性 </a>
 ｜<a href="#性能评测"> 性能评测 </a>
 ｜<a href="#环境安装"> 环境安装 </a>

--- a/tests/test_canonical_qwenaudio_links.py
+++ b/tests/test_canonical_qwenaudio_links.py
@@ -72,3 +72,23 @@ def test_tracked_files_use_qwenaudio_for_canonical_github_repositories():
             offenders.append(str(path.relative_to(ROOT)))
 
     assert not offenders, "legacy GitHub repository owner in: " + ", ".join(offenders)
+
+
+def test_readme_homepage_links_use_live_funasr_site():
+    targets = {
+        "README.md": "https://www.funasr.com/en/",
+        "README_zh.md": "https://www.funasr.com/",
+        "README_ja.md": "https://www.funasr.com/en/",
+        "README_ko.md": "https://www.funasr.com/en/",
+    }
+    for relpath, target in targets.items():
+        text = (ROOT / relpath).read_text(encoding="utf-8")
+        assert f'href="{target}"' in text, f"{relpath} is missing {target}"
+
+    offenders = []
+    for path, text in _tracked_text_files():
+        if path.resolve() == Path(__file__).resolve():
+            continue
+        if "funaudiollm.github.io" in text:
+            offenders.append(str(path.relative_to(ROOT)))
+    assert not offenders, "retired homepage domain in: " + ", ".join(offenders)


### PR DESCRIPTION
## Summary
- replace the retired `funaudiollm.github.io` homepage in all four localized READMEs
- route Chinese users to funasr.com and other locales to the English site
- guard all tracked files against reintroducing the retired domain

## Validation
- `python -m pytest tests -q` (23 passed)
- public destination URLs return HTTP 200
- `git diff --check`